### PR TITLE
MTDSA-22948: Deprecate APIs After Release 11

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -76,7 +76,6 @@ play.filters.cors {
 
 # Api related config
 api {
-  documentation-url = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/cis-deductions-api"
   # The status of the version of the API for the API Platform.
   1.0 {
     status = "DEPRECATED"
@@ -97,6 +96,7 @@ api {
 
   # The context which the API will have via the API Platform http://API_GATEWAY/{api.gateway.context}/
   gateway.context = "individuals/deductions/cis"
+  documentation-url = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/cis-deductions-api"
 }
 
 # HTTP Verbs related config

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -79,7 +79,7 @@ api {
   # The status of the version of the API for the API Platform.
   1.0 {
     status = "DEPRECATED"
-    deprecatedOn = "03/05/2023"
+    deprecatedOn = "2023-05-03"
     link = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/cis-deductions-api/1.0/oas/page"
     endpoints.enabled = true
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -76,6 +76,7 @@ play.filters.cors {
 
 # Api related config
 api {
+  documentation-url = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/cis-deductions-api"
   # The status of the version of the API for the API Platform.
   1.0 {
     status = "DEPRECATED"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -78,7 +78,9 @@ play.filters.cors {
 api {
   # The status of the version of the API for the API Platform.
   1.0 {
-    status = "BETA"
+    status = "DEPRECATED"
+    deprecatedOn = "03/05/2023"
+    link = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/cis-deductions-api/1.0/oas/page"
     endpoints.enabled = true
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -81,7 +81,6 @@ api {
   1.0 {
     status = "DEPRECATED"
     deprecatedOn = "2023-05-03"
-    link = "https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/cis-deductions-api/1.0/oas/page"
     endpoints.enabled = true
   }
 

--- a/it/config/DocumentationControllerISpec.scala
+++ b/it/config/DocumentationControllerISpec.scala
@@ -58,7 +58,7 @@ class DocumentationControllerISpec extends IntegrationBaseSpec {
       |      "versions":[
       |         {
       |            "version":"1.0",
-      |            "status":"BETA",
+      |            "status":"DEPRECATED",
       |            "endpointsEnabled":true
       |         },
       |         {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.21.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 


### PR DESCRIPTION
- Adds documentation-url, deprecatedOn and link fields to the application.conf file.
- Modifies status from “BETA” to “DEPRECATED”